### PR TITLE
Another fix for the complete() callback.

### DIFF
--- a/dive.js
+++ b/dive.js
@@ -68,6 +68,10 @@ module.exports = function(dir, opt, action, complete) {
           });
         }
       });
+      //empty directories
+      if(!list.length && !todo){
+	complete();
+      }
     });
   };
 


### PR DESCRIPTION
Complete callback wasn't getting called if the last tree element to be dived was an empty directory. This pull fixes that issue.

cheers
