### PR TITLE
failing call to complete callback if error occurs

### DIFF
--- a/dive.js
+++ b/dive.js
@@ -46,7 +46,10 @@ module.exports = function(dir, opt, action, complete) {
           var path = dir + '/' + file;
           // Get the file's stats
           fs.stat(path, function(err, stat) {
-            if (err) return action(err);
+            if (err) {
+              todo--;
+              return action(err);
+            }
 
             // If the file is a directory
             if (stat) {


### PR DESCRIPTION
if an error occurs while reading file.stat (line 48) the todo counter won't be decreased which will cause the complete callback will never be called.

i changed (line 48ff):

``` javascript
fs.stat(path, function(err, stat) {
    if (err) return action(err);
```

to:

``` javascript
fs.stat(path, function(err, stat) {
    if (err) {
        todo--;
        return action(err);
    }
```

hope you will merge this and update the npm package.
