### PR TITLE
fire complete for a dir with just hidden files

### DIFF
--- a/dive.js
+++ b/dive.js
@@ -75,8 +75,8 @@ module.exports = function(dir, opt, action, complete) {
           });
         }
       });
-      //empty directories
-      if(!list.length && !todo){
+      //empty directories, or with just hidden files
+      if (!todo){
         complete();
       }
     });


### PR DESCRIPTION
If you're having a directory like

foo
 .git
  gitstuff

the file list isn't actually empty, but todo is none, and right now, complete doesn't fire.

I don't think the check for the empty list is necessary, so I removed that.
